### PR TITLE
Refine site header and add playful about prompt

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -23,13 +23,9 @@
           <span></span>
         </div>
         <div class="brand-text">
-          <p class="eyebrow">The incident history you’d expect to see</p>
           <h1>The Missing GitHub Status Page</h1>
         </div>
       </div>
-      <nav class="site-nav">
-        <a href="#about">About</a>
-      </nav>
     </header>
 
     <main>
@@ -63,6 +59,10 @@
           </div>
         </div>
       </section>
+
+      <div class="about-prompt" data-animate>
+        <a href="#about"><span class="status-operational">Why</span> <span class="status-minor">is</span> <span class="status-operational">this</span> <span class="status-minor">page</span> <span class="status-major">'missing'</span><span class="status-operational">?</span> <span class="status-operational">Read</span> <span class="status-minor">about</span> <span class="status-operational">the</span> <span class="status-maintenance">mirror</span> →</a>
+      </div>
 
       <section class="panel panel-raise" data-animate>
         <div class="panel-header">

--- a/site/styles.css
+++ b/site/styles.css
@@ -52,34 +52,12 @@ a:hover {
   position: relative;
   z-index: 1;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding: 48px 24px 32px;
   gap: 24px;
   max-width: 850px;
   margin: 0 auto;
-}
-
-.site-nav {
-  display: flex;
-  gap: 16px;
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-
-.site-nav a {
-  color: var(--muted);
-  padding: 6px 10px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
-}
-
-.site-nav a:hover {
-  color: var(--ink);
-  border-color: var(--border);
-  background: #ffffff;
-  text-decoration: none;
 }
 
 .brand {
@@ -128,15 +106,6 @@ a:hover {
   margin: 0;
   font-family: var(--display);
   font-size: clamp(1.8rem, 2.8vw, 2.6rem);
-}
-
-.eyebrow {
-  margin: 0 0 6px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 600;
-  font-size: 0.7rem;
-  color: var(--muted);
 }
 
 .ghost-button {
@@ -487,6 +456,47 @@ main {
 
 .dot.maintenance {
   background: var(--maintenance);
+}
+
+.about-prompt {
+  text-align: center;
+  font-family: var(--display);
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.about-prompt a {
+  display: inline-block;
+  color: var(--ink);
+  text-decoration: none;
+  padding: 12px 20px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8) 0%, rgba(248, 250, 252, 0.8) 100%);
+  border: 1px solid var(--border);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.about-prompt a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px -15px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.about-prompt a .status-operational {
+  color: var(--operational);
+}
+
+.about-prompt a .status-minor {
+  color: var(--minor);
+}
+
+.about-prompt a .status-major {
+  color: var(--major);
+}
+
+.about-prompt a .status-maintenance {
+  color: var(--maintenance);
 }
 
 .panel {
@@ -904,11 +914,6 @@ details ul {
 @media (max-width: 980px) {
   .hero {
     grid-template-columns: 1fr;
-  }
-
-  .site-header {
-    flex-direction: column;
-    align-items: flex-start;
   }
 
   .hero-panel-header {


### PR DESCRIPTION
## Summary
- Remove eyebrow tagline to let the title stand alone
- Center header layout and remove About navigation button
- Add colorful call-to-action below uptime that playfully references the status bar colors
- Clean up unused CSS (eyebrow, site-nav styles)

## Changes
The new about prompt uses the same status colors (green/orange/red/blue) as the uptime bars above, creating a visual joke that reinforces the site's ironic tone.

<img width="866" height="667" alt="image" src="https://github.com/user-attachments/assets/e98e60b8-16ff-49a6-8567-4b2bc0d42c5d" />