### PR TITLE
feat: add uptime-since-acquisition metric

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -764,6 +764,35 @@ const render = async () => {
   const uptimePercent = document.getElementById('uptimePercent');
   uptimePercent.textContent = `${(uptime * 100).toFixed(2)}% uptime`;
 
+  const acquisitionDate = new Date('2018-10-26T00:00:00Z'); // https://blogs.microsoft.com/blog/2018/10/26/microsoft-completes-github-acquisition/
+
+  const acquisitionDowntimeIntervals = windowEntries
+    .filter((entry) => {
+      return countsAsDowntime(entry.impact) && entry.end instanceof Date && entry.end > acquisitionDate;
+    })
+    .map((entry) => {
+      const start = entry.start < acquisitionDate ? acquisitionDate : entry.start;
+      return [start, entry.end];
+    });
+
+  const mergedAcquisitionDowntime = mergeIntervals(acquisitionDowntimeIntervals);
+
+  const acquisitionDowntimeMinutes = mergedAcquisitionDowntime.reduce(
+    (total, [start, end]) => total + minutesBetween(start, end),
+    0
+  );
+
+  const acquisitionTotalMinutes = Math.max(1, minutesBetween(acquisitionDate, now));
+  const acquisitionUptime = 1 - acquisitionDowntimeMinutes / acquisitionTotalMinutes;
+
+  const sinceAcquisitionEl = document.getElementById('sinceAcquisitionStat');
+  if (sinceAcquisitionEl) {
+    sinceAcquisitionEl.innerHTML =
+      `${(acquisitionUptime * 100).toFixed(2)}% uptime since ` +
+      `<a href="https://blogs.microsoft.com/blog/2018/10/26/microsoft-completes-github-acquisition/" ` +
+      `target="_blank" rel="noreferrer">Microsoft acquired GitHub</a>`;
+  }
+
   const uptimeBars = document.getElementById('uptimeBars');
   const uptimeTooltip = document.getElementById('uptimeTooltip');
   const heroPanel = document.querySelector('.hero-panel');

--- a/site/index.html
+++ b/site/index.html
@@ -214,6 +214,14 @@
           <a href="https://web.archive.org/web/20190508015137/https://www.githubstatus.com/">2019 (new)</a>
         </p>
       </section>
+
+      <section class="panel panel-raise since-acquisition-panel" data-animate>
+        <div class="panel-header">
+          <h3>Other stats</h3>
+        </div>
+        <p class="since-acquisition-uptime" id="sinceAcquisitionStat"></p>
+        <p class="since-acquisition-note">Calculated from incident downtime windows since October 26, 2018 (excluding scheduled maintenance).</p>
+      </section>
     </main>
 
     <footer class="site-footer">

--- a/site/styles.css
+++ b/site/styles.css
@@ -734,6 +734,19 @@ main {
   gap: 6px;
 }
 
+.since-acquisition-panel .since-acquisition-uptime {
+  margin: 16px 0 4px;
+  font-size: 1.5rem;
+  font-family: var(--display);
+  font-weight: 700;
+}
+
+.since-acquisition-panel .since-acquisition-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
 .dot {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
This is a bit of a cheeky change coming from a conversation with people saying that they feel like the uptime is getting worse since the acquisition of GitHub by Microsoft.

Adds a "Other stats" panel at the bottom showing the uptime percentage since October 26, 2018 excluding scheduled maintenance windows.