### PR TITLE
Add flex-grow to history controls

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -1492,10 +1492,16 @@ main {
 
 .history-controls {
   display: flex;
+  flex-grow: 1;
   align-items: center;
   gap: 8px;
   font-weight: 600;
   color: var(--muted);
+}
+
+#historyRange {
+  flex-grow: 1;
+  text-align: center;
 }
 
 .icon-button {


### PR DESCRIPTION
To prevent the Previous button from moving each time it is clicked (at least on desktop)

Before:

<img width="845" height="270" alt="Screenshot 2026-04-28 at 8 09 49 PM" src="https://github.com/user-attachments/assets/4b4caf17-f584-404e-8071-47c2a3cc9a0c" />

After:

<img width="840" height="270" alt="Screenshot 2026-04-28 at 8 10 53 PM" src="https://github.com/user-attachments/assets/4880240d-0ac3-45e2-8505-fe1fe36cd685" />

Adding `text-wrap: nowrap` to "Uptime history" seems to help for mobile, but adding it will require more than just editing `site/styles.css`