### PR TITLE
fix(badges): aggregate incident timeline status count

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -129,6 +129,21 @@ const formatTime = (date) =>
 const incidentStartDate = (incident) =>
   incident.downtime_start ? new Date(incident.downtime_start) : new Date(incident.published_at);
 
+const summarizeStatuses = (statuses = []) => {
+  const counts = new Map();
+  const ordered = [];
+
+  statuses.filter(Boolean).forEach((status) => {
+    if (!counts.has(status)) ordered.push(status);
+    counts.set(status, (counts.get(status) || 0) + 1);
+  });
+
+  return ordered.map((status) => {
+    const count = counts.get(status);
+    return count > 1 ? `${status} (${count})` : status;
+  });
+};
+
 const parseJSONL = (text) =>
   text
     .split(/\r?\n/)
@@ -1265,7 +1280,7 @@ const renderIncidentCard = (incident, compact = false) => {
 
   const timeline = document.createElement('div');
   timeline.className = 'timeline';
-  (incident.status_sequence || []).forEach((status) => {
+  summarizeStatuses(incident.status_sequence).forEach((status) => {
     const pill = document.createElement('span');
     pill.textContent = status;
     timeline.appendChild(pill);

--- a/site/app.js
+++ b/site/app.js
@@ -130,18 +130,19 @@ const incidentStartDate = (incident) =>
   incident.downtime_start ? new Date(incident.downtime_start) : new Date(incident.published_at);
 
 const summarizeStatuses = (statuses = []) => {
-  const counts = new Map();
-  const ordered = [];
+  if (!Array.isArray(statuses)) return [];
 
-  statuses.filter(Boolean).forEach((status) => {
-    if (!counts.has(status)) ordered.push(status);
-    counts.set(status, (counts.get(status) || 0) + 1);
-  });
+  return statuses.filter(Boolean).reduce((summary, status) => {
+    const previous = summary[summary.length - 1];
 
-  return ordered.map((status) => {
-    const count = counts.get(status);
-    return count > 1 ? `${status} (${count})` : status;
-  });
+    if (previous?.status === status) {
+      previous.count += 1;
+    } else {
+      summary.push({ status, count: 1 });
+    }
+
+    return summary;
+  }, []).map(({ status, count }) => (count > 1 ? `${status} (${count})` : status));
 };
 
 const parseJSONL = (text) =>


### PR DESCRIPTION
## Description
I noticed that we have multiple Update/Resolved/etc badges on the site which by themselves don't hold that much more info, so might as well have one Update/Resolved/etc badge with the number near it for the updates.

## Screenshots
### Before
<img width="864" height="549" alt="SCR-20260429-jizz" src="https://github.com/user-attachments/assets/774afe15-928a-42f1-969b-9ab08401297f" />

### After
<img width="858" height="557" alt="SCR-20260429-jixq" src="https://github.com/user-attachments/assets/c300ca16-6df9-4c06-8407-941be9b789fa" />

## Summary
- aggregate repeated incident timeline statuses into a single badge per status
- append the total count for repeated statuses like `Update (7)` or `Resolved (2)`
- keep the original incident update history unchanged while simplifying the card timeline view