### PR TITLE
fix(bg) stabilize body gradient

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -185,10 +185,20 @@
 body {
   margin: 0;
   font-family: var(--mono);
-  background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg) 55%, var(--bg-bottom) 100%);
+  background: var(--bg);
   color: var(--ink);
   min-height: 100vh;
   position: relative;
+  isolation: isolate;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg) 55%, var(--bg-bottom) 100%);
+  pointer-events: none;
+  z-index: -1;
 }
 
 a {


### PR DESCRIPTION
## Description
Currently how the linear gradient background behaves the page seemingly turns into a full dark background when we press the Show More button in the Incident timeline. If you find this look subjectively worse ofc we can close the PR, but I think subjectively it creates a weird effect the seemingly darkened bg when we press the show more even though it is caused by stretching the body.

## Before

https://github.com/user-attachments/assets/cb5d2062-ce3a-47b7-9951-2a4cdcfb3a95


## After

https://github.com/user-attachments/assets/2ef8f0c4-5d41-412e-bc22-f3ba6eb00e9c


## Summary
- move the page gradient off `body` into a fixed background layer
- keep the solid body fallback, grain overlay, and content stacking unchanged
- prevent the incident timeline show more toggle from remapping the visible page background