### PR TITLE
Refine Uptime History UI

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -141,11 +141,13 @@
       </section>
 
       <section class="panel panel-raise" data-animate>
-        <div class="panel-header history-header">
-          <h3>Uptime history</h3>
+        <div class="panel-header">
+          <div>
+            <h3>Uptime history</h3>
+            <span class="muted" id="historyRange">Loading…</span>
+          </div>
           <div class="history-controls">
             <button class="icon-button" type="button" id="historyPrev" aria-label="Previous period">‹</button>
-            <span id="historyRange">Loading…</span>
             <button class="icon-button" type="button" id="historyNext" aria-label="Next period">›</button>
           </div>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1486,10 +1486,6 @@ main {
   text-decoration: none;
 }
 
-.history-header {
-  align-items: center;
-}
-
 .history-controls {
   display: flex;
   align-items: center;
@@ -2001,6 +1997,8 @@ details ul {
   .hero-panel-header,
   .panel-header {
     gap: 12px;
+    flex-direction: column;
+    align-items: start;
   }
 
   .hero-panel-header {


### PR DESCRIPTION
This pull request refines the UI of the Uptime History section by improving the visual layout and alignment.

The date range text has been moved beneath the **Uptime history** heading and styled with the `muted` class to better match the surrounding UI. The heading and date range are now grouped inside a separate container for better alignment.

Additionally, the control buttons are now left-aligned on mobile devices to improve usability on smaller screens, and the `history-header` class has been removed, as its styles are duplicated in the`panel-header` class.

### Destktop Before
<img width="780" height="256" alt="Screenshot 2026-05-05 at 9 36 00 AM" src="https://github.com/user-attachments/assets/c36d5920-82ff-4e46-a3bd-d4f93e59f570" />

### Desktop After
<img width="739" height="284" alt="Screenshot 2026-05-05 at 9 35 34 AM" src="https://github.com/user-attachments/assets/21486aeb-854d-4a0c-92b2-eb9814248b10" />

### Mobile Before
<img width="394" height="468" alt="Screenshot 2026-05-05 at 9 35 54 AM" src="https://github.com/user-attachments/assets/d48df0fb-014a-45b2-9334-0c16359bc429" />

### Mobile After
<img width="332" height="521" alt="Screenshot 2026-05-05 at 9 35 47 AM" src="https://github.com/user-attachments/assets/aceaca54-5f8f-4c19-87f2-bceab141894d" />
