### PR TITLE
Feature: add sorting by downtime duration and type

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -1185,34 +1185,64 @@ const render = async () => {
   const timeline = document.getElementById('incidentTimeline');
   timeline.innerHTML = '';
 
-  const grouped = new Map();
-  incidents.forEach((incident) => {
-    const date = formatDate(incidentStartDate(incident));
-    if (!grouped.has(date)) grouped.set(date, []);
-    grouped.get(date).push(incident);
-  });
+  const activeFilters = new Set();
 
-  const entries = Array.from(grouped.entries());
+  const getFilteredIncidents = () =>
+    activeFilters.size === 0
+      ? incidents
+      : incidents.filter((i) => activeFilters.has(i.impact || 'none'));
+
   let showAll = false;
+  let sortOrder = 'date-desc';
+  const sortSelect = document.getElementById('timelineSort');
   const toggleButtons = Array.from(document.querySelectorAll('[data-toggle-timeline]'));
 
   const renderTimeline = () => {
     timeline.innerHTML = '';
-    const slice = showAll ? entries : entries.slice(0, 8);
-    slice.forEach(([date, list]) => {
-      const group = document.createElement('div');
-      group.className = 'incident-group';
-
-      const heading = document.createElement('h4');
-      heading.textContent = date;
-      group.appendChild(heading);
-
-      list.forEach((incident) => {
-        group.appendChild(renderIncidentCard(incident));
+    const filtered = getFilteredIncidents();
+    if (sortOrder === 'date-desc') {
+      const grouped = new Map();
+      filtered.forEach((incident) => {
+        const date = formatDate(incidentStartDate(incident));
+        if (!grouped.has(date)) grouped.set(date, []);
+        grouped.get(date).push(incident);
       });
-
-      timeline.appendChild(group);
-    });
+      const entries = Array.from(grouped.entries());
+      const slice = showAll ? entries : entries.slice(0, 8);
+      slice.forEach(([date, list]) => {
+        const group = document.createElement('div');
+        group.className = 'incident-group';
+        const heading = document.createElement('h4');
+        heading.textContent = date;
+        group.appendChild(heading);
+        list.forEach((incident) => {
+          group.appendChild(renderIncidentCard(incident));
+        });
+        timeline.appendChild(group);
+      });
+    } else {
+      const sorted = filtered.slice().sort((a, b) => {
+        const aDur = a.duration_minutes ?? 0;
+        const bDur = b.duration_minutes ?? 0;
+        return sortOrder === 'duration-desc' ? bDur - aDur : aDur - bDur;
+      });
+      const slice = showAll ? sorted : sorted.slice(0, 20);
+      let lastDate = null;
+      let currentGroup = null;
+      slice.forEach((incident) => {
+        const date = formatDate(incidentStartDate(incident));
+        if (date !== lastDate) {
+          currentGroup = document.createElement('div');
+          currentGroup.className = 'incident-group';
+          const heading = document.createElement('h4');
+          heading.textContent = date;
+          currentGroup.appendChild(heading);
+          timeline.appendChild(currentGroup);
+          lastDate = date;
+        }
+        currentGroup.appendChild(renderIncidentCard(incident));
+      });
+    }
   };
 
   renderTimeline();
@@ -1224,9 +1254,31 @@ const render = async () => {
 
   updateToggleButtons();
 
+  if (sortSelect) {
+    sortSelect.addEventListener('change', () => {
+      sortOrder = sortSelect.value;
+      renderTimeline();
+    });
+  }
+
+  const filterPills = Array.from(document.querySelectorAll('[data-filter]'));
+  filterPills.forEach((pill) => {
+    pill.addEventListener('click', () => {
+      const filter = pill.dataset.filter;
+      if (activeFilters.has(filter)) {
+        activeFilters.delete(filter);
+        pill.setAttribute('aria-pressed', 'false');
+      } else {
+        activeFilters.add(filter);
+        pill.setAttribute('aria-pressed', 'true');
+      }
+      renderTimeline();
+    });
+  });
+
   toggleButtons.forEach((button) => {
     button.addEventListener('click', () => {
-    showAll = !showAll;
+      showAll = !showAll;
       updateToggleButtons();
       renderTimeline();
     });

--- a/site/app.js
+++ b/site/app.js
@@ -1193,8 +1193,8 @@ const render = async () => {
       : incidents.filter((i) => activeFilters.has(i.impact || 'none'));
 
   let showAll = false;
-  let sortOrder = 'date-desc';
   const sortSelect = document.getElementById('timelineSort');
+  let sortOrder = sortSelect ? sortSelect.value : 'date-desc';
   const toggleButtons = Array.from(document.querySelectorAll('[data-toggle-timeline]'));
 
   const renderTimeline = () => {

--- a/site/app.js
+++ b/site/app.js
@@ -14,6 +14,7 @@ const impactLabel = {
   maintenance: 'Maintenance',
   minor: 'Minor',
   major: 'Major',
+  critical: 'Critical',
 };
 
 const impactSummary = {
@@ -21,6 +22,7 @@ const impactSummary = {
   maintenance: 'Maintenance',
   minor: 'Partial outage',
   major: 'Major outage',
+  critical: 'Critical outage',
 };
 
 const SERVICES = [

--- a/site/index.html
+++ b/site/index.html
@@ -158,8 +158,19 @@
         <div class="panel-header">
           <h3>Incident timeline</h3>
           <div class="panel-actions">
+            <select class="sort-select" id="timelineSort" aria-label="Sort incidents by">
+              <option value="date-desc">Date (newest first)</option>
+              <option value="duration-desc">Duration (longest first)</option>
+              <option value="duration-asc">Duration (shortest first)</option>
+            </select>
             <button class="ghost-button" type="button" id="togglePast" data-toggle-timeline>Show more</button>
           </div>
+        </div>
+        <div class="timeline-filters">
+          <button class="filter-pill filter-pill-major" type="button" data-filter="major" aria-pressed="false">Major</button>
+          <button class="filter-pill filter-pill-minor" type="button" data-filter="minor" aria-pressed="false">Minor</button>
+          <button class="filter-pill filter-pill-maintenance" type="button" data-filter="maintenance" aria-pressed="false">Maintenance</button>
+          <button class="filter-pill filter-pill-operational" type="button" data-filter="none" aria-pressed="false">Operational</button>
         </div>
         <div id="incidentTimeline"></div>
         <div class="timeline-footer">

--- a/site/index.html
+++ b/site/index.html
@@ -158,7 +158,7 @@
         <div class="panel-header">
           <h3>Incident timeline</h3>
           <div class="panel-actions">
-            <select class="sort-select" id="timelineSort" aria-label="Sort incidents by">
+            <select class="sort-select" id="timelineSort" aria-label="Sort incidents by" autocomplete="off">
               <option value="date-desc">Date (newest first)</option>
               <option value="duration-desc">Duration (longest first)</option>
               <option value="duration-asc">Duration (shortest first)</option>

--- a/site/index.html
+++ b/site/index.html
@@ -167,6 +167,7 @@
           </div>
         </div>
         <div class="timeline-filters">
+          <button class="filter-pill filter-pill-critical" type="button" data-filter="critical" aria-pressed="false">Critical</button>
           <button class="filter-pill filter-pill-major" type="button" data-filter="major" aria-pressed="false">Major</button>
           <button class="filter-pill filter-pill-minor" type="button" data-filter="minor" aria-pressed="false">Minor</button>
           <button class="filter-pill filter-pill-maintenance" type="button" data-filter="maintenance" aria-pressed="false">Maintenance</button>

--- a/site/styles.css
+++ b/site/styles.css
@@ -568,6 +568,88 @@ a:hover {
   box-shadow: 0 10px 22px -15px rgba(0, 0, 0, 0.3);
 }
 
+.timeline-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  padding: 14px 0 2px;
+  position: relative;
+  margin-top: 4px;
+}
+
+.timeline-filters::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 10%;
+  right: 10%;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--border), transparent);
+}
+
+.filter-pill {
+  border-radius: 999px;
+  padding: 5px 13px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: opacity 0.15s ease, box-shadow 0.15s ease;
+  font-family: inherit;
+}
+
+.filter-pill-major {
+  background: rgba(207, 34, 46, 0.12);
+  color: var(--badge-major-ink);
+  border: 1px solid rgba(207, 34, 46, 0.3);
+}
+
+.filter-pill-minor {
+  background: rgba(217, 119, 6, 0.12);
+  color: var(--badge-minor-ink);
+  border: 1px solid rgba(217, 119, 6, 0.3);
+}
+
+.filter-pill-maintenance {
+  background: rgba(31, 111, 235, 0.12);
+  color: var(--badge-maintenance-ink);
+  border: 1px solid rgba(31, 111, 235, 0.3);
+}
+
+.filter-pill-operational {
+  background: rgba(45, 164, 78, 0.12);
+  color: var(--badge-operational-ink);
+  border: 1px solid rgba(45, 164, 78, 0.3);
+}
+
+.filter-pill[aria-pressed="false"] {
+  opacity: 0.38;
+}
+
+.filter-pill[aria-pressed="true"] {
+  opacity: 1;
+  box-shadow: 0 0 0 2px currentColor;
+}
+
+.sort-select {
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: 999px;
+  padding: 10px 36px 10px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+}
+
 main {
   position: relative;
   z-index: 1;

--- a/site/styles.css
+++ b/site/styles.css
@@ -80,6 +80,7 @@
   --icon-button-bg: #ffffff;
   --badge-minor-ink: #8a4b00;
   --badge-major-ink: #8a1f24;
+  --badge-critical-ink: #6b0f2a;
   --badge-maintenance-ink: #1f4d8f;
   --badge-operational-ink: #1b5f33;
   --source-tab-bg: linear-gradient(180deg, #11121a 0%, #24292f 100%);
@@ -164,6 +165,7 @@
     --icon-button-bg: #161b22;
     --badge-minor-ink: #e3b341;
     --badge-major-ink: #ffa198;
+    --badge-critical-ink: #ffb3c6;
     --badge-maintenance-ink: #79c0ff;
     --badge-operational-ink: #7ee787;
     --source-tab-bg: linear-gradient(180deg, #161b22 0%, #24292f 100%);
@@ -598,6 +600,12 @@ a:hover {
   cursor: pointer;
   transition: opacity 0.15s ease, box-shadow 0.15s ease;
   font-family: inherit;
+}
+
+.filter-pill-critical {
+  background: rgba(136, 19, 55, 0.12);
+  color: var(--badge-critical-ink);
+  border: 1px solid rgba(136, 19, 55, 0.3);
 }
 
 .filter-pill-major {
@@ -1796,6 +1804,11 @@ main {
 .badge.major {
   background: rgba(207, 34, 46, 0.16);
   color: var(--badge-major-ink);
+}
+
+.badge.critical {
+  background: rgba(136, 19, 55, 0.16);
+  color: var(--badge-critical-ink);
 }
 
 .badge.maintenance {


### PR DESCRIPTION
### Summary


Introduces the ability to sort by the longest/shortest downtime events in Github history. Can also sort by the disruption type (critical, major, minor, maintenance, or operational).

---

### Motivation

Out of curiosity, I wanted to see what events caused the largest disruptions in Github downtime history, since it's genuinely interesting to read the post-mortem reports that are usually included. 

---

### Screenshots

<img width="886" height="752" alt="Screenshot 2026-05-14 at 10 18 21 AM" src="https://github.com/user-attachments/assets/8de0769b-96ac-46d0-86e2-2a54cbc199e3" />

<img width="867" height="753" alt="Screenshot 2026-05-14 at 10 18 40 AM" src="https://github.com/user-attachments/assets/35d9e585-075d-4ec1-8a6f-e90ca547208d" />

---

### Changes

- Sort dropdown in the Incident Timeline panel header with three options: Date (newest first), Duration (longest first), Duration (shortest first)
- Filter pills row below the panel header to toggle visibility by impact type: Major, Minor, Maintenance, Operational — multiple filters can be active simultaneously
- Duration sort flattens grouped-by-date layout into a ranked flat list (capped at 20 items before "Show more")
- Filter state is independent of sort order — both apply together on every render
autocomplete="off" on the sort select prevents browser form-state persistence across page refreshes